### PR TITLE
Indicate failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ osx_image: xcode8.3
 before_install:
  - External/objective-git/script/bootstrap
 script:
- - xcodebuild -workspace GitX.xcworkspace -scheme GitX build | xcpretty
+ - set -o pipefail && xcodebuild -workspace GitX.xcworkspace -scheme GitX build | xcpretty


### PR DESCRIPTION
The Travis build fails for each commit for some time but the build error is suppressed due to using a pipe with `xcpretty`. This fixes the suppression of build errors.

